### PR TITLE
결제 성공 시 결제창 뜨지 않게 설정

### DIFF
--- a/src/app/(afterLogin)/mainpage/_component/chatroom.tsx
+++ b/src/app/(afterLogin)/mainpage/_component/chatroom.tsx
@@ -80,6 +80,7 @@ interface ChatRoomProps {
     type?: "BASIC" | "STANDARD" | "ELITE" | "DEMO";
     role?: "LEADER" | "MEMBER";
     roomImageUrl?: string;
+    paymentStatus?: "NOT_PAID" | "PAID";
   };
   onRoomUpdate?: (roomId: string, unreadCount: number) => void;
   onRefreshRoom?: () => void;
@@ -127,7 +128,7 @@ export default function ChatRoom({ roomData, onRoomUpdate, onRefreshRoom }: Chat
   const [message, setMessage] = useState<string>("");
   const [displayMessages, setDisplayMessages] = useState<ChatMessageType[]>([]);
   const [hoveredMessage, setHoveredMessage] = useState<number | null>(null);
-  const [showPayment, setShowPayment] = useState<boolean>(true);
+  const [showPayment, setShowPayment] = useState<boolean>(roomData.paymentStatus === "NOT_PAID");
   const [isSuccessCompleted, setIsSuccessCompleted] = useState<boolean>(false);
   const [showExitModal, setShowExitModal] = useState<boolean>(false);
   const [showSuccessModal, setShowSuccessModal] = useState<boolean>(false);
@@ -200,11 +201,7 @@ export default function ChatRoom({ roomData, onRoomUpdate, onRefreshRoom }: Chat
 
   const handleRoomSuccess = useCallback((event: RoomSuccessEvent) => {
     console.log("팀플 성공 알림 수신:", event);
-
-    // 모든 멤버에게 성공 모달 표시
     setShowSuccessModal(true);
-
-    // 모든 멤버에게 나가기 버튼 표시
     setIsSuccessCompleted(true);
   }, []);
 
@@ -264,6 +261,10 @@ export default function ChatRoom({ roomData, onRoomUpdate, onRefreshRoom }: Chat
       setMembers(roomData.members);
     }
   }, [roomData.members]);
+
+  useEffect(() => {
+    setShowPayment(roomData.paymentStatus === "NOT_PAID");
+  }, [roomData.paymentStatus]);
 
   const targetMemberCount: number = roomData.memberCount || members.length || 0;
 

--- a/src/types/room.ts
+++ b/src/types/room.ts
@@ -18,4 +18,5 @@ export interface Room {
   type?: "BASIC" | "STANDARD" | "ELITE" | "DEMO";
   role?: "LEADER" | "MEMBER";
   roomImageUrl?: string;
+  paymentStatus?: "NOT_PAID" | "PAID";
 }


### PR DESCRIPTION
1. RoomData 인터페이스에 paymentStatus: "NOT_PAID" | "PAID" 추가
2. paymentStatus로 결제 성공 여부를 판단하여 새로고침해도 안뜨게 설정했습니다